### PR TITLE
Drop Spark event when cannot be serialized

### DIFF
--- a/src/main/scala/co/datamechanics/delight/Configs.scala
+++ b/src/main/scala/co/datamechanics/delight/Configs.scala
@@ -57,6 +57,6 @@ object Configs {
     s"$sanitizedAppName-$uuid"
   }
 
-  val delightVersion: String = "1.0.2"
+  val delightVersion: String = "1.0.3"
 
 }


### PR DESCRIPTION
In rare cases, Spark events cannot be serialized.
This happened recently on Databricks:
```
com.fasterxml.jackson.databind.JsonMappingException: Exceeded 2097152 bytes (current = 2100278)
(through reference chain: org.apache.spark.sql.catalyst.expressions.AttributeReference["canonicalized"]->org.apache.spark.s...
...
Caused by: com.databricks.spark.util.LimitedOutputStream$LimitExceededException: Exceeded 2097152 bytes (current = 2100278)
```

It seems to be a known but unaddressed issue:
https://forums.databricks.com/questions/44005/encountering-limitexceededexception-in-a-spark-job.html

In the meantime, we protect the agent against this case.