### PR TITLE
set executor.metrics.pollingInterval to 5s

### DIFF
--- a/src/main/scala/co/datamechanics/delight/DelightListener.scala
+++ b/src/main/scala/co/datamechanics/delight/DelightListener.scala
@@ -18,7 +18,7 @@ class DelightListener(sparkConf: SparkConf) extends SparkListener with Logging {
    * For Spark versions below 3.0.0, these configs have no effect.
    */
   sparkConf.set("spark.executor.processTreeMetrics.enabled", "true")
-  sparkConf.set("spark.executor.metrics.pollingInterval", "10ms")
+  sparkConf.set("spark.executor.metrics.pollingInterval", "5s")
 
   private val shouldLogDuration = Configs.logDuration(sparkConf)
 


### PR DESCRIPTION
We got return that `spark.executor.metrics.pollingInterval` set to `10ms` had an impact on CPU for some users

This should allow us to keep the CPU usage in check while still retrieving relevent data 