### PR TITLE
feat: use Databricks cluster name override

### DIFF
--- a/src/main/scala/co/datamechanics/delight/Configs.scala
+++ b/src/main/scala/co/datamechanics/delight/Configs.scala
@@ -51,9 +51,12 @@ object Configs {
   }
 
   def generateDMAppId(sparkConf: SparkConf): String = {
-    val appName: String = sparkConf.get("spark.delight.appNameOverride", sparkConf.get("spark.app.name", "undefined"))
-    val sanitizedAppName: String = appName.replaceAll("\\W", "-").replaceAll("--*", "-").stripSuffix("-")
-    val uuid: String = java.util.UUID.randomUUID().toString
+    val appName = sparkConf.getOption("spark.delight.appNameOverride")
+      .orElse(sparkConf.getOption("spark.databricks.clusterUsageTags.clusterName"))
+      .orElse(sparkConf.getOption("spark.app.name"))
+      .getOrElse("undefined")
+    val sanitizedAppName = appName.replaceAll("\\W", "-").replaceAll("--*", "-").stripSuffix("-")
+    val uuid = java.util.UUID.randomUUID().toString
     s"$sanitizedAppName-$uuid"
   }
 


### PR DESCRIPTION
In Databricks, users can override the name of their cluster with the
following Spark conf key: spark.databricks.clusterUsageTags.clusterName.

If this config is present, it is used to override the Spark app name,
with lower precedence than spark.delight.appNameOverride.